### PR TITLE
Pin Dockerfile ubuntu: image digest - autoclosed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:latest@sha256:e348fbbea0e0a0e73ab0370de151e7800684445c509d46195aef73e090a49bd6
 
 RUN apt-get update && apt-get -y upgrade && \
      apt-get install -y \


### PR DESCRIPTION
This Pull Request pins Docker base image `ubuntu:` to use a digest (`sha256:e348fbbea0e0a0e73ab0370de151e7800684445c509d46195aef73e090a49bd6`).
This digest will then be kept updated via Pull Requests whenever the image is updated on the Docker registry. For details on Renovate's Docker support, please visit https://renovateapp.com/docs/language-support/docker


**Important**: Renovate will wait until you have merged this Pin request before creating PRs for any *upgrades*. If you do not wish to pin anything, please update your config accordingly instead of leaving this PR open.